### PR TITLE
web: include drone,nginx,watchtower in highstate

### DIFF
--- a/state/top.sls
+++ b/state/top.sls
@@ -2,8 +2,11 @@
   '*':
     - users
   'web.spritsail.io':
+    - drone
     - gitea
     - imageinfo
+    - nginx
     - quotesdb
     - teamspeak3
+    - watchtower
     - wekan


### PR DESCRIPTION
These states should always be included in the highstate for this host.

Signed-off-by: Joe Groocock <me@frebib.net>