### PR TITLE
apt: no-install-recommends by default

### DIFF
--- a/state/apt/init.sls
+++ b/state/apt/init.sls
@@ -1,0 +1,11 @@
+# https://jpetazzo.github.io/2013/10/06/policy-rc-d-do-not-start-services-automatically/
+/usr/sbin/policy-rc.d:
+  file.managed:
+    - contents: exit 101
+    - mode: 0755
+
+/etc/apt/apt.conf.d/02-recommends.conf:
+  file.managed:
+    - contents: |
+        APT::Get::Install-Recommends "false";
+        APT::Get::Install-Suggests "false";

--- a/state/docker/install.sls
+++ b/state/docker/install.sls
@@ -1,3 +1,6 @@
+include:
+- apt
+
 docker_repo:
   pkgrepo.managed:
     - name: deb https://download.docker.com/linux/debian {{ grains.oscodename }} stable
@@ -13,11 +16,14 @@ docker-deps:
       - docker-ce-cli
       - python3-pip
     - require:
+      - sls: apt
       - pkgrepo: docker_repo
 
 docker-ce:
   pkg.installed:
     - version: {{ salt.pillar.get("docker:version", "latest") }}
+    - require:
+      - pkg: docker-deps
 
 docker-compose:
   pip.installed:

--- a/state/nettools.sls
+++ b/state/nettools.sls
@@ -1,6 +1,11 @@
+include:
+- apt
+
 install_network_packages:
   pkg.installed:
     - pkgs:
        - curl
        - vim
+    - require:
+      - sls: apt
 


### PR DESCRIPTION
Also disable apt restarting services; Salt should be handling that
instead.

Signed-off-by: Joe Groocock <me@frebib.net>